### PR TITLE
Fixed manual trigger order.

### DIFF
--- a/SVPullToRefresh/UIScrollView+SVPullToRefresh.m
+++ b/SVPullToRefresh/UIScrollView+SVPullToRefresh.m
@@ -98,8 +98,8 @@ static char UIScrollViewPullToRefreshView;
 }
 
 - (void)triggerPullToRefresh {
-    self.pullToRefreshView.state = SVPullToRefreshStateTriggered;
     [self.pullToRefreshView startAnimating];
+    self.pullToRefreshView.state = SVPullToRefreshStateTriggered;
 }
 
 - (void)setPullToRefreshView:(SVPullToRefreshView *)pullToRefreshView {


### PR DESCRIPTION
When the state was set before the "startAnimating" function was called, the "stopAnimating" function could be called before the state was completely set. In that case, the animation would run forever.
