### PR TITLE
Hide infinite scrolling view after animation stopped

### DIFF
--- a/SVPullToRefresh/UIScrollView+SVInfiniteScrolling.m
+++ b/SVPullToRefresh/UIScrollView+SVInfiniteScrolling.m
@@ -62,6 +62,7 @@ UIEdgeInsets scrollViewOriginalContentInsets;
         view.originalBottomInset = self.contentInset.bottom;
         self.infiniteScrollingView = view;
         self.showsInfiniteScrolling = YES;
+        [view resetScrollViewContentInset];
     } else {
         self.infiniteScrollingView.infiniteScrollingHandler = actionHandler;
     }
@@ -296,10 +297,12 @@ UIEdgeInsets scrollViewOriginalContentInsets;
         
         switch (newState) {
             case SVInfiniteScrollingStateStopped:
+                [self resetScrollViewContentInset];
                 [self.activityIndicatorView stopAnimating];
                 break;
                 
             case SVInfiniteScrollingStateTriggered:
+                [self setScrollViewContentInsetForInfiniteScrolling];
                 [self.activityIndicatorView startAnimating];
                 break;
                 


### PR DESCRIPTION
The infinite scrolling view always take up the bottom space,  say I have a long list, I scroll it fast and after my finger left the screen, the scroll view may stop at the empty infinite view(without the activity indicator), but it'll not trigger a refresh action. I need to drag the scroll view again, to make it refresh.

That a little bit weird, so I make the infinite scrolling view hide for default, only show it after user trigger the action, and hide it again after the animation stopped.

Hope this helps.
